### PR TITLE
Update dependencies and refactor start function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ name = "api"
 path = "src/api.rs"
 
 [dependencies]
-regex = "1.5.4"
-clap = { version = "4.2.4", features = ["derive"] }
-toml = "0.8.0"
-walkdir = "2.3.2"
-rayon = "1.5.1"
+regex = "1.10.3"
+clap = { version = "4.5.3", features = ["derive"] }
+toml = "0.8.12"
+walkdir = "2.5.0"
+rayon = "1.9.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
@@ -27,9 +27,9 @@ mockito = "1.0.2"
 csv = "1.1"
 log = "0.4"
 env_logger = "0.11.0"
-axum = { version = "0.6.1", features = ["headers", "macros"] }
-tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
+axum = { version = "0.7.4", features = ["macros"] }
+tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.5.0", features = ["cors"] }
-utoipa = { version = "3.3.0", features = ["axum_extras"] }
-utoipa-swagger-ui = { version = "3.1.3", features = ["axum"] }
-hyper = { version = "0.14", features = ["full"] }
+utoipa = { version = "4.2.0", features = ["axum_extras"] }
+utoipa-swagger-ui = { version = "6", features = ["axum"] }
+hyper = { version = "1.2.0", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod service{
     pub mod git_service;
 }
  
- pub use entity::models;
+pub use entity::models;
  
 
 pub use errors::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,16 +25,7 @@ pub use utils::git_util;
 pub use git_util::*;
 pub use models::*;
 
-
-
-
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    
-};
-
-use axum::{routing, Router, Server};
-use hyper::Error;
+use axum::{routing, Router};
 use utoipa::{
      OpenApi,
 };
@@ -53,7 +44,7 @@ pub use routes::rules::*;
  
  
 
-pub async fn start() -> Result<(), Error> {
+pub async fn start() -> Result<(), Box<dyn std::error::Error>> {
     #[derive(OpenApi)]
     #[openapi(
         paths(
@@ -84,9 +75,9 @@ pub async fn start() -> Result<(), Error> {
         .route("/rules/delete_rules_by_id", routing::post(delete_rules_by_id))
         .route("/rules/update", routing::post(update_rules));
 
-
-    let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 7000));
-    Server::bind(&address).serve(app.into_make_service()).await
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:7000").await.unwrap();
+    axum::serve(listener, app.into_make_service()).await?;
+    Ok(())
 }
 
  

--- a/src/service/git_service.rs
+++ b/src/service/git_service.rs
@@ -109,8 +109,8 @@ pub fn handle_commits_file(
 
     let mut commits: Vec<String> = Vec::new();
 
-    // Read each line from the file and store it in the commits vector
-    for line in reader.lines().flatten() {
+    // Read each line from the file, stopping at the first error
+    for line in reader.lines().map_while(Result::ok) {
         commits.push(line);
     }
 

--- a/src/utils/detect_utils.rs
+++ b/src/utils/detect_utils.rs
@@ -378,7 +378,6 @@ pub fn append_rule_to_toml(rule: &Rule, filename: &str) -> Result<(), Box<dyn st
     // Open the file with read, write, and append options
     let mut file = OpenOptions::new()
         .read(true)
-        .write(true)
         .append(true)
         .open(filename)?;
 


### PR DESCRIPTION
- Update regex requirement from 1.5.4 to 1.10.3.
- Update clap requirement from 4.2.4 to 4.5.3.
- Update toml requirement from 0.8.0 to 0.8.12.
- Update walkdir requirement from 2.3.2 to 2.5.0.
- Update rayon requirement from 1.5.1 to 1.9.1.
- Update axum requirement from 0.6.1 to 0.7.4.
- Update tokio requirement from 1.21.2 to 1.36.0.
- Update tower-http requirement to 0.5.0 (unchanged but included for completeness).
- Update utoipa requirement from 3.3.0 to 4.2.0.
- Update utoipa-swagger-ui requirement from 3.1.3 to 6.
- Update hyper requirement from 0.14 to 1.2.0.